### PR TITLE
Deep match option values to account for objects etc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 /** @jsx dom */
-import arrayUniq from 'array-uniq';
 import clickOutside from 'click-outside';
+import deepEqual from 'deep-equal';
 import dom from 'magic-virtual-element';
+import findIndex from 'lodash.findindex';
+import uniq from 'uniq';
 import Option from './option';
 
 const propTypes = {
@@ -63,12 +65,12 @@ const onRemove = (val, props, state, setState) => {
 	const {active} = state;
 	const arr = active.map(x => x.value);
 
-	active.splice(arr.indexOf(val), 1);
+	active.splice(findIndex(arr, x => deepEqual(x, val)), 1);
 
 	setState({active});
 
 	if (onChange) {
-		onChange({[name]: arrayUniq(active.map(x => x.value))});
+		onChange({[name]: uniq(active.map(x => x.value), (a, b) => !deepEqual(a, b))});
 	}
 
 	return;
@@ -104,8 +106,8 @@ const onClick = (option, props, state, setState) => {
 	const arr = active.map(x => x.value);
 	let ret = [option];
 
-	if (arr.includes(option.value)) {
-		active.splice(arr.indexOf(option.value), 1);
+	if (arr.some(x => deepEqual(x, option.value))) {
+		active.splice(findIndex(arr, x => deepEqual(x, option.value)), 1);
 
 		const obj = {active};
 
@@ -116,7 +118,7 @@ const onClick = (option, props, state, setState) => {
 		setState(obj);
 
 		if (onChange) {
-			onChange({[name]: arrayUniq(active.map(x => x.value))});
+			onChange({[name]: uniq(active.map(x => x.value), (a, b) => !deepEqual(a, b))});
 		}
 
 		return;
@@ -126,10 +128,10 @@ const onClick = (option, props, state, setState) => {
 		ret = active.filter(x => x.value).concat(ret);
 	}
 
-	setState({active: arrayUniq(ret), open: multiple && !forceClose ? open : false});
+	setState({active: uniq(ret, (a, b) => !deepEqual(a, b)), open: multiple && !forceClose ? open : false});
 
 	if (onChange) {
-		onChange({[name]: arrayUniq(ret.map(x => x.value))});
+		onChange({[name]: uniq(ret.map(x => x.value), (a, b) => !deepEqual(a, b))});
 	}
 };
 
@@ -139,7 +141,7 @@ const getOptions = (props, state, setState) => {
 	const arr = active.filter(x => x.value).map(x => x.value);
 
 	return options.map(x => {
-		return <Option active={arr.includes(x.value)} data={x} onClick={() => onClick(x, props, state, setState)}/>;
+		return <Option active={arr.some(y => deepEqual(y, x.value))} data={x} onClick={() => onClick(x, props, state, setState)}/>;
 	});
 };
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
     "select"
   ],
   "dependencies": {
-    "array-uniq": "^1.0.2",
     "click-outside": "^1.0.4",
-    "magic-virtual-element": "^1.0.6"
+    "deep-equal": "^1.0.1",
+    "lodash.findindex": "^4.3.0",
+    "magic-virtual-element": "^1.0.6",
+    "uniq": "^1.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",


### PR DESCRIPTION
Currently, only string and number values works. This adds support for having objects and arrays as values.
